### PR TITLE
Quick Fix to GJS Versioning and A Making Extension run on Lockscreen

### DIFF
--- a/ubuntunetspeed@ochi12.github.com/metadata.json
+++ b/ubuntunetspeed@ochi12.github.com/metadata.json
@@ -3,8 +3,10 @@
   "description": "A simple extension that shows the current network speed",
   "uuid": "ubuntunetspeed@ochi12.github.com",
   "version": 2,
+  "version-name": "2.0.2",
   "shell-version": [
     "45", "46", "47", "48"
   ],
+  "session-modes": ["user", "unlock-dialog"],
   "url": "https://github.com/ochi12/ubuntu-net-speed/"
 }


### PR DESCRIPTION
 - Added version-name to metadata.json

 - version-name is now at 2.0.2

